### PR TITLE
Use GNUInstallDirs for controlling install destinations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(BADVPN C)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 
+include(GNUInstallDirs)
 include(TestBigEndian)
 include(CheckIncludeFiles)
 include(CheckSymbolExists)
@@ -243,7 +244,7 @@ endif ()
 # install man pages
 install(
     FILES badvpn.7
-    DESTINATION share/man/man7
+	DESTINATION ${CMAKE_INSTALL_MANDIR}/man7
 )
 
 # reset variables indicating whether we're building various libraries,

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -21,10 +21,10 @@ target_link_libraries(badvpn-client system flow flowextra tuntap server_conectio
 
 install(
     TARGETS badvpn-client
-    RUNTIME DESTINATION bin
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 install(
     FILES badvpn-client.8
-    DESTINATION share/man/man8
+    DESTINATION ${CMAKE_INSTALL_MANDIR}/man8
 )

--- a/flooder/CMakeLists.txt
+++ b/flooder/CMakeLists.txt
@@ -3,5 +3,5 @@ target_link_libraries(badvpn-flooder system flow server_conection ${NSPR_LIBRARI
 
 install(
     TARGETS badvpn-flooder
-    RUNTIME DESTINATION bin
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/ncd-request/CMakeLists.txt
+++ b/ncd-request/CMakeLists.txt
@@ -5,5 +5,5 @@ target_link_libraries(badvpn-ncd-request ncdrequest ncdvalgenerator ncdvalparser
 
 install(
     TARGETS badvpn-ncd-request
-    RUNTIME DESTINATION bin
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/ncd/CMakeLists.txt
+++ b/ncd/CMakeLists.txt
@@ -189,7 +189,7 @@ if (NOT EMSCRIPTEN)
     
     install(
         TARGETS badvpn-ncd
-        RUNTIME DESTINATION bin
+		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 endif ()
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -3,10 +3,10 @@ target_link_libraries(badvpn-server system flow flowextra nspr_support predicate
 
 install(
     TARGETS badvpn-server
-    RUNTIME DESTINATION bin
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 install(
     FILES badvpn-server.8
-    DESTINATION share/man/man8
+    DESTINATION ${CMAKE_INSTALL_MANDIR}/man8
 )

--- a/tun2socks/CMakeLists.txt
+++ b/tun2socks/CMakeLists.txt
@@ -6,10 +6,10 @@ target_link_libraries(badvpn-tun2socks system flow tuntap lwip socksclient udpgw
 
 install(
     TARGETS badvpn-tun2socks
-    RUNTIME DESTINATION bin
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 install(
     FILES badvpn-tun2socks.8
-    DESTINATION share/man/man8
+    DESTINATION ${CMAKE_INSTALL_MANDIR}/man8
 )

--- a/tunctl/CMakeLists.txt
+++ b/tunctl/CMakeLists.txt
@@ -2,5 +2,5 @@ add_executable(badvpn-tunctl tunctl.c)
 
 install(
     TARGETS badvpn-tunctl
-    RUNTIME DESTINATION bin
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/udpgw/CMakeLists.txt
+++ b/udpgw/CMakeLists.txt
@@ -5,5 +5,5 @@ target_link_libraries(badvpn-udpgw system flow flowextra)
 
 install(
     TARGETS badvpn-udpgw
-    RUNTIME DESTINATION bin
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )


### PR DESCRIPTION
This allows proper control over install destinations, especially
when 'bin' has a different prefix than 'share', e.g.:
* /usr/x86_64-pc-linux-gnu/bin/
* /usr/share