### PR TITLE
Fix output file name and source folders conflict

### DIFF
--- a/compile-tun2sock.sh
+++ b/compile-tun2sock.sh
@@ -5,6 +5,7 @@
 
 # Input environment vars:
 #   SRCDIR - BadVPN source code
+#   OUTDIR - tun2socks binary output file directory
 #   CC - compiler
 #   CFLAGS - compiler compile flags
 #   LDFLAGS - compiler link flags
@@ -111,4 +112,4 @@ for f in $SOURCES; do
     OBJS=( "${OBJS[@]}" "${obj}" )
 done
 
-"${CC}" ${LDFLAGS} "${OBJS[@]}" -o tun2socks -lrt
+"${CC}" ${LDFLAGS} "${OBJS[@]}" -o $OUTDIR/tun2socks -lrt


### PR DESCRIPTION
Output file name and source directory _tun2socks_ conflict fail to execute directly in the source code root directory _compile-tun2socks.sh_.