### PR TITLE
Fix output file name and source folders conflict

### DIFF
--- a/compile-tun2sock.sh
+++ b/compile-tun2sock.sh
@@ -5,6 +5,7 @@
 
 # Input environment vars:
 #   SRCDIR - BadVPN source code
+#   OUTDIR - tun2socks binary output file directory
 #   CC - compiler
 #   CFLAGS - compiler compile flags
 #   LDFLAGS - compiler link flags
@@ -16,6 +17,11 @@
 
 if [[ -z $SRCDIR ]] || [[ ! -e $SRCDIR/CMakeLists.txt ]]; then
     echo "SRCDIR is wrong"
+    exit 1
+fi
+
+if [[ ! -z $OUTDIR ]] && [[ ! -d $OUTDIR  ]]; then
+    echo "OUTDIR is wrong"
     exit 1
 fi
 
@@ -43,6 +49,8 @@ DEFS=( -DBADVPN_THREAD_SAFE=0 -DBADVPN_LINUX -DBADVPN_BREACTOR_BADVPN -D_GNU_SOU
 [[ $KERNEL = "2.4" ]] && DEFS=( "${DEFS[@]}" -DBADVPN_USE_SELFPIPE -DBADVPN_USE_POLL ) || DEFS=( "${DEFS[@]}" -DBADVPN_USE_SIGNALFD -DBADVPN_USE_EPOLL )
 
 [[ $ENDIAN = "little" ]] && DEFS=( "${DEFS[@]}" -DBADVPN_LITTLE_ENDIAN ) || DEFS=( "${DEFS[@]}" -DBADVPN_BIG_ENDIAN )
+
+[[ -z $OUTDIR ]] && OUTDIR="."
     
 SOURCES="
 base/BLog_syslog.c
@@ -111,4 +119,4 @@ for f in $SOURCES; do
     OBJS=( "${OBJS[@]}" "${obj}" )
 done
 
-"${CC}" ${LDFLAGS} "${OBJS[@]}" -o tun2socks -lrt
+"${CC}" ${LDFLAGS} "${OBJS[@]}" -o $OUTDIR/tun2socks -lrt


### PR DESCRIPTION
Output file name and source directory tun2socks conflict fail to execute directly in the source code root directory compile-tun2socks.sh.