### PR TITLE
This fixes build of the project on Windows

### DIFF
--- a/system/BConnection_win.c
+++ b/system/BConnection_win.c
@@ -796,7 +796,7 @@ int BConnection_GetLocalAddress (BConnection *o, BAddr *local_addr)
 {
     DebugObject_Access(&o->d_obj);
     
-    struct BDatagram_sys_addr sysaddr;
+    struct sys_addr sysaddr;
     socklen_t addr_size = sizeof(sysaddr.addr.generic);
     if (getsockname(o->sock, &sysaddr.addr.generic, &addr_size) != 0) {
         BLog(BLOG_ERROR, "BConnection_GetLocalAddress: getsockname failed");
@@ -809,7 +809,7 @@ int BConnection_GetLocalAddress (BConnection *o, BAddr *local_addr)
     
     if (addr.type == BADDR_TYPE_NONE) {
         BLog(BLOG_ERROR, "BConnection_GetLocalAddress: Unsupported address family "
-            "from getsockname: %d", int(sysaddr.addr.generic.sa_family));
+            "from getsockname: %d", sysaddr.addr.generic.sa_family);
         return 0;
     }
 

--- a/system/BDatagram_win.c
+++ b/system/BDatagram_win.c
@@ -652,7 +652,7 @@ int BDatagram_GetLocalAddr (BDatagram *o, BAddr *local_addr)
     
     if (addr.type == BADDR_TYPE_NONE) {
         BLog(BLOG_ERROR, "BDatagram_GetLocalAddr: Unsupported address family "
-            "from getsockname: %d", int(sysaddr.addr.generic.sa_family));
+            "from getsockname: %d", sysaddr.addr.generic.sa_family);
         return 0;
     }
 


### PR DESCRIPTION
I tried to build the _master_ branch of the project with `-DBUILD_NOTHING_BY_DEFAULT=1 -DBUILD_TUN2SOCKS=1 -DBUILD_UDPGW=1` on **Windows**. It failed with multiple exceptions:
```
...
Build FAILED.

"C:\Programming\projects\badvpn\build\install.vcxproj" (default target) (1) ->
"C:\Programming\projects\badvpn\build\ALL_BUILD.vcxproj" (default target) (3) ->
"C:\Programming\projects\badvpn\build\tun2socks\badvpn-tun2socks.vcxproj" (default target) (4) ->
"C:\Programming\projects\badvpn\build\flowextra\flowextra.vcxproj" (default target) (7) ->
"C:\Programming\projects\badvpn\build\system\system.vcxproj" (default target) (8) ->
(ClCompile target) ->
  c:\programming\projects\badvpn\system\bconnection_win.c(801): warning C4133: 'function': incompatible types - from 's
ocklen_t *' to 'sockaddr *' [C:\Programming\projects\badvpn\build\system\system.vcxproj]
  c:\programming\projects\badvpn\system\bconnection_win.c(808): warning C4024: 'addr_sys_to_socket': different types fo
r formal and actual parameter 2 [C:\Programming\projects\badvpn\build\system\system.vcxproj]


"C:\Programming\projects\badvpn\build\install.vcxproj" (default target) (1) ->
"C:\Programming\projects\badvpn\build\ALL_BUILD.vcxproj" (default target) (3) ->
"C:\Programming\projects\badvpn\build\tun2socks\badvpn-tun2socks.vcxproj" (default target) (4) ->
"C:\Programming\projects\badvpn\build\flowextra\flowextra.vcxproj" (default target) (7) ->
"C:\Programming\projects\badvpn\build\system\system.vcxproj" (default target) (8) ->
(ClCompile target) ->
  c:\programming\projects\badvpn\system\bconnection_win.c(799): error C2079: 'sysaddr' uses undefined struct 'BDatagram
_sys_addr' [C:\Programming\projects\badvpn\build\system\system.vcxproj]
  c:\programming\projects\badvpn\system\bconnection_win.c(800): error C2224: left of '.addr' must have struct/union typ
e [C:\Programming\projects\badvpn\build\system\system.vcxproj]
  c:\programming\projects\badvpn\system\bconnection_win.c(801): error C2224: left of '.addr' must have struct/union typ
e [C:\Programming\projects\badvpn\build\system\system.vcxproj]
  c:\programming\projects\badvpn\system\bconnection_win.c(801): error C2198: 'getsockname': too few arguments for call
[C:\Programming\projects\badvpn\build\system\system.vcxproj]
  c:\programming\projects\badvpn\system\bconnection_win.c(805): error C2224: left of '.len' must have struct/union type
 [C:\Programming\projects\badvpn\build\system\system.vcxproj]
  c:\programming\projects\badvpn\system\bconnection_win.c(808): error C2440: 'function': cannot convert from 'int' to '
sys_addr' [C:\Programming\projects\badvpn\build\system\system.vcxproj]
  c:\programming\projects\badvpn\system\bconnection_win.c(812): error C2059: syntax error: 'type' [C:\Programming\proje
cts\badvpn\build\system\system.vcxproj]
  c:\programming\projects\badvpn\system\bdatagram_win.c(655): error C2059: syntax error: 'type' [C:\Programming\project
s\badvpn\build\system\system.vcxproj]

    2 Warning(s)
    8 Error(s)
```
I Identified the problem was brought by few commits: e837e8d552156e26ed52a67923a91268d6e1192a and 6241fc29783a68934ce6ab979915abc8845900a2:
* in the _BConnection_win.c_ `sys_addr` type is used defined in the same class instead of the `BDatagram_sys_addr` defined in the `BDatagram_win.h`. Latter even not included.
* there is an attempt to pass `int()` parameter as an argument to `BLog` function. The syntax is incorrect.