### PR TITLE
Fix installation steps for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ cd <badvpn-source-dir>
 mkdir build
 cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=<install-dir>
+cd ..
 make install
 ```
 


### PR DESCRIPTION
Cause if exec make install in './build' dir error occurs: "make: *** No rule to make target 'install'.  Stop."